### PR TITLE
Feat: Restrict form view mode to read-only for Admin

### DIFF
--- a/src/components/ui/EditableFormCard.tsx
+++ b/src/components/ui/EditableFormCard.tsx
@@ -63,10 +63,10 @@ export type FormDtoSchema = z.infer<typeof FormDto>;
 
 interface UpdateFormProps {
   form: ApplicationForm | Form;
-  readOnly?: boolean;
+  readonly?: boolean;
 }
 
-export default function EditableFormCard({ form, readOnly = false }: UpdateFormProps) {
+export default function EditableFormCard({ form, readonly = false }: UpdateFormProps) {
   const defaultValues = {
     name: form.name,
     description: form.description ?? "",
@@ -100,7 +100,7 @@ export default function EditableFormCard({ form, readOnly = false }: UpdateFormP
   };
 
   const onSubmit = async (data: FormDtoSchema) => {
-    if (readOnly) return;
+    if (readonly) return;
 
     const requestBody: Partial<FormDtoSchema> = {};
     for (const key in dirtyFields) {
@@ -136,7 +136,7 @@ export default function EditableFormCard({ form, readOnly = false }: UpdateFormP
   };
 
   const handleAddQuestion = async () => {
-    if (readOnly) return;
+    if (readonly) return;
     await createQuestion({
       jwt: cookies.jwt,
       formId: form._id,
@@ -144,7 +144,6 @@ export default function EditableFormCard({ form, readOnly = false }: UpdateFormP
     });
   };
 
-  console.log('readonly', readOnly)
   return (
     <form className="flex gap-2 group" onSubmit={handleSubmit(onSubmit)}>
       {isDeleteFormLoading && (
@@ -156,21 +155,18 @@ export default function EditableFormCard({ form, readOnly = false }: UpdateFormP
         <input
           placeholder="Enter title"
           className={`outline-none text-[42px] font-bold border-b border-black/10 ${
-            readOnly ? "bg-gray-100 cursor-not-allowed" : ""
+            readonly ? "bg-gray-100 cursor-not-allowed" : ""
           }`}
           {...register("name")}
-          readOnly={readOnly}
-          disabled={readOnly}
+          disabled={readonly}
         />
         <input
           placeholder="Enter description"
           className={`outline-none border-b border-black/10 ${
-            readOnly ? "bg-gray-100 cursor-not-allowed" : ""
+            readonly ? "bg-gray-100 cursor-not-allowed" : ""
           }`}
           {...register("description")}
-          style={readOnly ? { pointerEvents: "none" } : {}}
-          readOnly={readOnly}
-          disabled={readOnly}
+          disabled={readonly}
         />
         {form.type === FormType.Application && (
           <>
@@ -181,10 +177,10 @@ export default function EditableFormCard({ form, readOnly = false }: UpdateFormP
                 render={({ field, ...props }) => (
                   <DatePicker
                     value={field.value ?? null}
-                    onChange={readOnly ? undefined : field.onChange}
+                    onChange={readonly ? undefined : field.onChange}
                     label="Application open date"
                     {...props}
-                    disabled={readOnly}
+                    disabled={readonly}
                   />
                 )}
               />
@@ -194,10 +190,10 @@ export default function EditableFormCard({ form, readOnly = false }: UpdateFormP
                 render={({ field, ...props }) => (
                   <DatePicker
                     value={field.value ?? null}
-                    onChange={readOnly ? undefined : field.onChange}
+                    onChange={readonly ? undefined : field.onChange}
                     label="Application close date"
                     {...props}
-                    disabled={readOnly}
+                    disabled={readonly}
                   />
                 )}
               />
@@ -206,12 +202,12 @@ export default function EditableFormCard({ form, readOnly = false }: UpdateFormP
               control={control}
               register={register}
               error={errors}
-              readOnly={readOnly}
+              readOnly={readonly}
             />
           </>
         )}
       </div>
-      {!readOnly && (
+      {!readonly && (
         <div className="flex flex-col justify-between gap-6 p-4 max-h-48 custom-shadow rounded-xl">
           {isDirty ? (
             <button type="submit">

--- a/src/components/ui/EditableFormCard.tsx
+++ b/src/components/ui/EditableFormCard.tsx
@@ -1,15 +1,15 @@
-import CheckMark from "../../assets/CheckMarkIcon"
-import AddIcon from "../../assets/AddIcon"
-import { Controller, useForm } from "react-hook-form"
+import CheckMark from "../../assets/CheckMarkIcon";
+import AddIcon from "../../assets/AddIcon";
+import { Controller, useForm } from "react-hook-form";
 import {
   useCreateQuestionMutation,
   useDeleteFormMutation,
   useEditFormMutation,
-} from "../../features/user/backendApi"
-import SuccessCheckMark from "../../assets/SuccessCheckMarkIcon"
-import Delete from "../../assets/DeleteIcon"
-import Loader from "./Loader"
-import { useNavigate } from "react-router-dom"
+} from "../../features/user/backendApi";
+import SuccessCheckMark from "../../assets/SuccessCheckMarkIcon";
+import Delete from "../../assets/DeleteIcon";
+import Loader from "./Loader";
+import { useNavigate } from "react-router-dom";
 import {
   AlertType,
   ApplicationForm,
@@ -17,16 +17,16 @@ import {
   Form,
   FormType,
   QuestionType,
-} from "../../utils/types"
-import { useCookies } from "react-cookie"
-import dayjs from "dayjs"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { z } from "zod"
-import UpdateStages from "./UpdateStages"
-import { DatePicker } from "@mui/x-date-pickers"
-import { getErrorInfo } from "../../utils/helper"
-import { handleShowAlert } from "../../utils/handleShowAlert"
-import { useDispatch } from "react-redux"
+} from "../../utils/types";
+import { useCookies } from "react-cookie";
+import dayjs from "dayjs";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import UpdateStages from "./UpdateStages";
+import { DatePicker } from "@mui/x-date-pickers";
+import { getErrorInfo } from "../../utils/helper";
+import { handleShowAlert } from "../../utils/handleShowAlert";
+import { useDispatch } from "react-redux";
 
 const FormDto = z.object({
   name: z.string().optional(),
@@ -37,7 +37,7 @@ const FormDto = z.object({
         value === null || dayjs.isDayjs(value) || value instanceof Date,
       {
         message: "Start date must be a valid Date",
-      },
+      }
     )
     .transform((value) => (dayjs.isDayjs(value) ? value.toDate() : value)),
   endDate: z
@@ -46,7 +46,7 @@ const FormDto = z.object({
         value === null || dayjs.isDayjs(value) || value instanceof Date,
       {
         message: "End date must be a valid Date",
-      },
+      }
     )
     .transform((value) => (dayjs.isDayjs(value) ? value.toDate() : value)),
   stages: z
@@ -54,18 +54,19 @@ const FormDto = z.object({
       z.object({
         name: z.string().min(2, "Name is required"),
         description: z.string(),
-      }),
+      })
     )
     .optional(),
-})
+});
 
-export type FormDtoSchema = z.infer<typeof FormDto>
+export type FormDtoSchema = z.infer<typeof FormDto>;
 
 interface UpdateFormProps {
-  form: ApplicationForm | Form
+  form: ApplicationForm | Form;
+  readOnly?: boolean;
 }
 
-export default function EditableFormCard({ form }: UpdateFormProps) {
+export default function EditableFormCard({ form, readOnly = false }: UpdateFormProps) {
   const defaultValues = {
     name: form.name,
     description: form.description ?? "",
@@ -73,9 +74,10 @@ export default function EditableFormCard({ form }: UpdateFormProps) {
       form.type === FormType.Application ? dayjs(form.startDate) : null,
     endDate: form.type === FormType.Application ? dayjs(form.endDate) : null,
     stages: form.type === FormType.Application ? form.stages : [],
-  }
-  const [cookies] = useCookies([Cookie.jwt])
-  const dispatch = useDispatch()
+  };
+
+  const [cookies] = useCookies([Cookie.jwt]);
+  const dispatch = useDispatch();
   const {
     control,
     register,
@@ -84,26 +86,27 @@ export default function EditableFormCard({ form }: UpdateFormProps) {
   } = useForm<FormDtoSchema>({
     resolver: zodResolver(FormDto),
     defaultValues,
-  })
+  });
 
-  const [editForm] = useEditFormMutation()
-  const [createQuestion] = useCreateQuestionMutation()
-  const navigate = useNavigate()
+  const [editForm] = useEditFormMutation();
+  const [createQuestion] = useCreateQuestionMutation();
+  const navigate = useNavigate();
 
   const [deleteForm, { isLoading: isDeleteFormLoading }] =
-    useDeleteFormMutation()
+    useDeleteFormMutation();
   const handleDeleteForm = async () => {
-    await deleteForm({ jwt: cookies.jwt, _id: form._id })
-    navigate(`/forms`)
-  }
+    await deleteForm({ jwt: cookies.jwt, _id: form._id });
+    navigate(`/forms`);
+  };
 
   const onSubmit = async (data: FormDtoSchema) => {
-    const requestBody: Partial<FormDtoSchema> = {}
+    if (readOnly) return;
 
+    const requestBody: Partial<FormDtoSchema> = {};
     for (const key in dirtyFields) {
-      const myKey = key as keyof FormDtoSchema
-      if (!dirtyFields[myKey]) continue
-      requestBody[myKey] = data[myKey] as any
+      const myKey = key as keyof FormDtoSchema;
+      if (!dirtyFields[myKey]) continue;
+      requestBody[myKey] = data[myKey] as any;
     }
 
     try {
@@ -111,52 +114,63 @@ export default function EditableFormCard({ form }: UpdateFormProps) {
         jwt: cookies.jwt,
         id: form._id,
         body: requestBody,
-      })
+      });
 
       if (result.error) {
-        throw result.error
+        throw result.error;
       }
 
       handleShowAlert(dispatch, {
         type: AlertType.Success,
         message: "Form updated successfully",
-      })
+      });
 
-      navigate(`/forms/${result?.data?._id}`)
+      navigate(`/forms/${result?.data?._id}`);
     } catch (error) {
-      const { message } = getErrorInfo(error)
+      const { message } = getErrorInfo(error);
       handleShowAlert(dispatch, {
         type: AlertType.Error,
         message,
-      })
+      });
     }
-  }
+  };
 
   const handleAddQuestion = async () => {
+    if (readOnly) return;
     await createQuestion({
       jwt: cookies.jwt,
       formId: form._id,
       body: { prompt: `Question`, type: QuestionType.Text },
-    })
-  }
+    });
+  };
 
+  console.log('readonly', readOnly)
   return (
-    <form className="group flex gap-2" onSubmit={handleSubmit(onSubmit)}>
+    <form className="flex gap-2 group" onSubmit={handleSubmit(onSubmit)}>
       {isDeleteFormLoading && (
-        <div className="absolute inset-0 h-full w-full">
+        <div className="absolute inset-0 w-full h-full">
           <Loader />
         </div>
       )}
-      <div className="p-8 custom-shadow border-t-primary-dark group-focus-within:border-t-primary-light border-t-8  rounded-xl flex flex-col gap-8 flex-1">
+      <div className="flex flex-col flex-1 gap-8 p-8 border-t-8 custom-shadow border-t-primary-dark group-focus-within:border-t-primary-light rounded-xl">
         <input
           placeholder="Enter title"
-          className="outline-none text-[42px] font-bold border-b border-black/10"
+          className={`outline-none text-[42px] font-bold border-b border-black/10 ${
+            readOnly ? "bg-gray-100 cursor-not-allowed" : ""
+          }`}
           {...register("name")}
+          readOnly={readOnly}
+          disabled={readOnly}
         />
         <input
           placeholder="Enter description"
-          className="outline-none border-b border-black/10"
+          className={`outline-none border-b border-black/10 ${
+            readOnly ? "bg-gray-100 cursor-not-allowed" : ""
+          }`}
           {...register("description")}
+          style={readOnly ? { pointerEvents: "none" } : {}}
+          readOnly={readOnly}
+          disabled={readOnly}
         />
         {form.type === FormType.Application && (
           <>
@@ -167,9 +181,10 @@ export default function EditableFormCard({ form }: UpdateFormProps) {
                 render={({ field, ...props }) => (
                   <DatePicker
                     value={field.value ?? null}
-                    onChange={field.onChange}
+                    onChange={readOnly ? undefined : field.onChange}
                     label="Application open date"
                     {...props}
+                    disabled={readOnly}
                   />
                 )}
               />
@@ -179,9 +194,10 @@ export default function EditableFormCard({ form }: UpdateFormProps) {
                 render={({ field, ...props }) => (
                   <DatePicker
                     value={field.value ?? null}
-                    onChange={field.onChange}
+                    onChange={readOnly ? undefined : field.onChange}
                     label="Application close date"
                     {...props}
+                    disabled={readOnly}
                   />
                 )}
               />
@@ -190,25 +206,28 @@ export default function EditableFormCard({ form }: UpdateFormProps) {
               control={control}
               register={register}
               error={errors}
+              readOnly={readOnly}
             />
           </>
         )}
       </div>
-      <div className="flex flex-col justify-between max-h-48 gap-6 p-4 custom-shadow rounded-xl">
-        {isDirty ? (
-          <button type="submit">
-            <SuccessCheckMark />
+      {!readOnly && (
+        <div className="flex flex-col justify-between gap-6 p-4 max-h-48 custom-shadow rounded-xl">
+          {isDirty ? (
+            <button type="submit">
+              <SuccessCheckMark />
+            </button>
+          ) : (
+            <CheckMark />
+          )}
+          <button type="button" onClick={handleAddQuestion}>
+            <AddIcon />
           </button>
-        ) : (
-          <CheckMark />
-        )}
-        <button type="button" onClick={handleAddQuestion}>
-          <AddIcon />
-        </button>
-        <button type="button" onClick={handleDeleteForm}>
-          <Delete />
-        </button>
-      </div>
+          <button type="button" onClick={handleDeleteForm}>
+            <Delete />
+          </button>
+        </div>
+      )}
     </form>
-  )
+  );
 }

--- a/src/components/ui/FormCard.tsx
+++ b/src/components/ui/FormCard.tsx
@@ -25,17 +25,17 @@ const FormCard = ({ form }: { form: IFormType }) => {
   }
 
   return (
-    <div className="p-8 custom-shadow flex items-center justify-between rounded-xl">
+    <div className="flex items-center justify-between p-8 custom-shadow rounded-xl">
       {isDeleteFormLoading && (
-        <div className="absolute inset-0 h-full w-full flex items-center justify-center">
+        <div className="absolute inset-0 flex items-center justify-center w-full h-full">
           <Loader />
         </div>
       )}
-      <div className="flex flex-col gap-4 w-full">
+      <div className="flex flex-col w-full gap-4">
         <div className="flex justify-between">
           <div className="flex gap-2">
             <H2>{form.name}</H2>
-            <div className="flex items-center gap-1 font-bold text-primary-dark border-primary-dark border rounded-lg px-6 ">
+            <div className="flex items-center gap-1 px-6 font-bold border rounded-lg text-primary-dark border-primary-dark ">
               <H7>{form.type}</H7>
             </div>
           </div>
@@ -48,7 +48,7 @@ const FormCard = ({ form }: { form: IFormType }) => {
         <H6>{form.description}</H6>
         <div className="flex justify-between">
           <button
-            onClick={() => navigate(`/forms/${form._id}`)}
+            onClick={() => navigate(`/forms/${form._id}?edit=false`)}
             className="flex items-center gap-2"
           >
             <View />

--- a/src/components/ui/QuestionCard.tsx
+++ b/src/components/ui/QuestionCard.tsx
@@ -1,21 +1,21 @@
-import React, { useState } from "react"
-import Loader from "./Loader"
-import Delete from "../../assets/DeleteIcon"
+import { useState } from "react";
+import Loader from "./Loader";
+import Delete from "../../assets/DeleteIcon";
 import {
   useDeleteQuestionMutation,
   useEditQuestionMutation,
-} from "../../features/user/backendApi"
-import SuccessCheckMark from "../../assets/SuccessCheckMarkIcon"
-import { useForm } from "react-hook-form"
-import AddIcon from "../../assets/AddIcon"
-import RemoveIcon from "../../assets/RemoveIcon"
-import Reset from "../../assets/ResetIcon"
-import DeleteModal from "../modals/DeleteModal"
-import { Cookie, QuestionType } from "../../utils/types"
-import { useCookies } from "react-cookie"
+} from "../../features/user/backendApi";
+import SuccessCheckMark from "../../assets/SuccessCheckMarkIcon";
+import { useForm } from "react-hook-form";
+import AddIcon from "../../assets/AddIcon";
+import RemoveIcon from "../../assets/RemoveIcon";
+import Reset from "../../assets/ResetIcon";
+import DeleteModal from "../modals/DeleteModal";
+import { Cookie, QuestionType } from "../../utils/types";
+import { useCookies } from "react-cookie";
 
-const QuestionCard = ({ question }: any) => {
-  const { prompt, type, options, _id } = question
+const QuestionCard = ({ question, readonly }: { question: any; readonly: boolean }) => {
+  const { prompt, type, options, _id } = question;
   const {
     register,
     handleSubmit,
@@ -29,59 +29,55 @@ const QuestionCard = ({ question }: any) => {
       type,
       options,
     },
-  })
-  const [cookies] = useCookies([Cookie.jwt])
-  const [deleteQuestion] = useDeleteQuestionMutation()
-  const [editQuestion] = useEditQuestionMutation()
-  const [showDeleteModal, setShowDeleteModal] = useState(false)
+  });
+  const [cookies] = useCookies([Cookie.jwt]);
+  const [deleteQuestion] = useDeleteQuestionMutation();
+  const [editQuestion] = useEditQuestionMutation();
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const handleDeleteQuestion = async (_id: string) => {
-    await deleteQuestion({ jwt: cookies.jwt, id: _id })
-    setShowDeleteModal(false)
-  }
+    await deleteQuestion({ jwt: cookies.jwt, id: _id });
+    setShowDeleteModal(false);
+  };
 
   const changeOptionsHandler = (value: string, index: number) => {
-    const updatedOptions = [...currentOptions]
-    updatedOptions[index] = value
-    setValue("options", updatedOptions, { shouldDirty: true })
-  }
+    const updatedOptions = [...currentOptions];
+    updatedOptions[index] = value;
+    setValue("options", updatedOptions, { shouldDirty: true });
+  };
 
   const onSubmit = async (data: any) => {
-    await editQuestion({ jwt: cookies.jwt, body: data, id: _id })
-  }
+    await editQuestion({ jwt: cookies.jwt, body: data, id: _id });
+  };
 
-  const { type: selectedType } = watch()
-  const { options: currentOptions } = watch()
+  const { type: selectedType } = watch();
+  const { options: currentOptions } = watch();
 
   return (
     <div className="flex justify-start gap-2 group">
-      <div className="p-8 custom-shadow group-focus-within:border-l-8 group-focus-within:border-primary-light flex flex-1 items-center justify-between rounded-xl">
+      <div className="flex items-center justify-between flex-1 p-8 custom-shadow group-focus-within:border-l-8 group-focus-within:border-primary-light rounded-xl">
         {false && (
-          <div className="absolute inset-0 h-full w-full">
+          <div className="absolute inset-0 w-full h-full">
             <Loader />
           </div>
         )}
-        <div className="w-full justify-between gap-4- cursor-pointer">
+        <div className="justify-between w-full cursor-pointer gap-4-">
           <div className="flex items-center gap-4">
             <input
               {...register("prompt")}
-              className={`text-2xl flex-1 h-16 focus:border-b-2 border-primary-light outline-none py-1 px-0.5`}
+              className="text-2xl flex-1 h-16 focus:border-b-2 border-primary-light outline-none py-1 px-0.5"
+              disabled={readonly}
             />
-            <select className="p-2" {...register("type")} value={selectedType}>
+            <select className="p-2" {...register("type")} value={selectedType} disabled={readonly}>
               {[
                 { label: "Text", value: QuestionType.Text },
                 { label: "Single choice", value: QuestionType.SingleSelect },
                 { label: "Multiple choice", value: QuestionType.MultiSelect },
-              ].map(
-                (
-                  currentType: { label: string; value: string },
-                  index: number,
-                ) => (
-                  <option key={index} value={currentType.value}>
-                    {currentType.label}
-                  </option>
-                ),
-              )}
+              ].map((currentType : { label: string; value: string }, index : number) => (
+                <option key={index} value={currentType.value}>
+                  {currentType.label}
+                </option>
+              ))}
             </select>
           </div>
           {(selectedType === QuestionType.SingleSelect ||
@@ -89,62 +85,62 @@ const QuestionCard = ({ question }: any) => {
             <div>
               <ol className="w-full my-4">
                 {currentOptions.map((option: string, index: number) => (
-                  <li key={index} className="flex gap-3 items-center">
+                  <li key={index} className="flex items-center gap-3">
                     <span>{index + 1}.</span>
                     <input
                       defaultValue={option}
                       className="text-lg flex-1 focus:border-black hover:border-gray-300 hover:border-b focus:duration-300 ease-in-out focus:border-b outline-none py-1 px-0.5"
-                      onChange={(e) =>
-                        changeOptionsHandler(e.target.value, index)
-                      }
+                      onChange={(e) => changeOptionsHandler(e.target.value, index)}
+                      disabled={readonly}
                     />
                   </li>
                 ))}
               </ol>
-              <button
-                onClick={() =>
-                  setValue(
-                    "options",
-                    [...currentOptions, `option ${currentOptions.length + 1}`],
-                    { shouldDirty: true },
-                  )
-                }
-              >
-                <AddIcon />
-              </button>
-              {currentOptions.length > 0 && (
-                <button
-                  onClick={() => {
-                    const updatedOptions = [...currentOptions]
-                    updatedOptions.pop()
-                    setValue("options", updatedOptions, { shouldDirty: true })
-                  }}
-                >
-                  <RemoveIcon />
-                </button>
+              {!readonly && (
+                <>
+                  <button
+                    onClick={() =>
+                      setValue("options", [...currentOptions, `option ${currentOptions.length + 1}`], {
+                        shouldDirty: true,
+                      })
+                    }
+                  >
+                    <AddIcon />
+                  </button>
+                  {currentOptions.length > 0 && (
+                    <button
+                      onClick={() => {
+                        const updatedOptions = [...currentOptions];
+                        updatedOptions.pop();
+                        setValue("options", updatedOptions, { shouldDirty: true });
+                      }}
+                    >
+                      <RemoveIcon />
+                    </button>
+                  )}
+                </>
               )}
             </div>
           )}
         </div>
       </div>
-      <div className="max-h-44 flex flex-col justify-center gap-6 p-4 custom-shadow rounded-xl">
-        {isDirty ? (
-          <div className="flex flex-col gap-6">
-            <button type="submit" onClick={handleSubmit(onSubmit)}>
-              <SuccessCheckMark />
-            </button>
-            <button type="submit" onClick={() => reset()}>
-              <Reset />
-            </button>
-          </div>
-        ) : null}
-        <button
-          onClick={() => setShowDeleteModal(true)}
-          className="flex items-center gap-2"
-        >
-          <Delete />
-        </button>
-      </div>
+      {!readonly && (
+        <div className="flex flex-col justify-center gap-6 p-4 max-h-44 custom-shadow rounded-xl">
+          {isDirty && (
+            <div className="flex flex-col gap-6">
+              <button type="submit" onClick={handleSubmit(onSubmit)}>
+                <SuccessCheckMark />
+              </button>
+              <button type="submit" onClick={() => reset()}>
+                <Reset />
+              </button>
+            </div>
+          )}
+          <button onClick={() => setShowDeleteModal(true)} className="flex items-center gap-2">
+            <Delete />
+          </button>
+        </div>
+      )}
       {showDeleteModal && (
         <DeleteModal
           title="a question"
@@ -154,7 +150,7 @@ const QuestionCard = ({ question }: any) => {
         />
       )}
     </div>
-  )
-}
+  );
+};
 
-export default QuestionCard
+export default QuestionCard;

--- a/src/components/ui/QuestionCard.tsx
+++ b/src/components/ui/QuestionCard.tsx
@@ -6,15 +6,15 @@ import {
   useEditQuestionMutation,
 } from "../../features/user/backendApi";
 import SuccessCheckMark from "../../assets/SuccessCheckMarkIcon";
-import { useForm } from "react-hook-form";
+import { SubmitHandler, useForm } from "react-hook-form";
 import AddIcon from "../../assets/AddIcon";
 import RemoveIcon from "../../assets/RemoveIcon";
 import Reset from "../../assets/ResetIcon";
 import DeleteModal from "../modals/DeleteModal";
-import { Cookie, QuestionType } from "../../utils/types";
+import {  Cookie, QuestionType, TemplateQuestion } from "../../utils/types";
 import { useCookies } from "react-cookie";
 
-const QuestionCard = ({ question, readonly }: { question: any; readonly: boolean }) => {
+const QuestionCard = ({ question, readonly }: { question: TemplateQuestion; readonly: boolean }) => {
   const { prompt, type, options, _id } = question;
   const {
     register,
@@ -46,7 +46,8 @@ const QuestionCard = ({ question, readonly }: { question: any; readonly: boolean
     setValue("options", updatedOptions, { shouldDirty: true });
   };
 
-  const onSubmit = async (data: any) => {
+
+  const onSubmit:  SubmitHandler<Omit<TemplateQuestion, '_id' | 'responses' | 'required'>> = async (data) => {
     await editQuestion({ jwt: cookies.jwt, body: data, id: _id });
   };
 

--- a/src/components/ui/UpdateStages.tsx
+++ b/src/components/ui/UpdateStages.tsx
@@ -27,9 +27,10 @@ type UpdateStageProps = {
   control: Control<{ stages: Stage[]; [key: string]: any }>
   register?: UseFormRegister<any>
   error: any
+  readOnly?: boolean
 }
 
-export default function UpdateStages({ control, error }: UpdateStageProps) {
+export default function UpdateStages({ control, error, readOnly }: UpdateStageProps) {
   const { fields, append, remove } = useFieldArray({
     control,
     name: "stages",
@@ -48,7 +49,7 @@ export default function UpdateStages({ control, error }: UpdateStageProps) {
 
   return (
     <Disclosure as="div" className="p-4 border rounded-md">
-      <DisclosureButton className="w-full flex items-center justify-between">
+      <DisclosureButton className="flex items-center justify-between w-full">
         <h1 className="text-2xl">Stages</h1>
         <DropDownIcon className="w-8 h-8" />
       </DisclosureButton>
@@ -75,6 +76,7 @@ export default function UpdateStages({ control, error }: UpdateStageProps) {
                     size="small"
                     fullWidth
                     placeholder={`Stage ${index + 1} Name`}
+                    disabled={readOnly}
                   />
                 </>
               )}
@@ -94,6 +96,7 @@ export default function UpdateStages({ control, error }: UpdateStageProps) {
                     size="small"
                     fullWidth
                     placeholder={`Stage ${index + 1} Description`}
+                    disabled={readOnly}
                   />
                 </>
               )}
@@ -112,12 +115,12 @@ export default function UpdateStages({ control, error }: UpdateStageProps) {
                 size={ButtonSize.Small}
                 variant={ButtonVariant.Danger}
                 onClick={handleRemoveStage}
-                disabled={fields.length === 1}
+                disabled={readOnly || fields.length === 1}
               >
                 Remove Stage
               </Button>
             )}
-          <Button size={ButtonSize.Small} onClick={handleAddStage}>
+          <Button size={ButtonSize.Small} onClick={handleAddStage} disabled={readOnly}>
             Add Stage
           </Button>
         </Stack>

--- a/src/pages/Form/Form.tsx
+++ b/src/pages/Form/Form.tsx
@@ -10,6 +10,7 @@ import { handleShowAlert } from "../../utils/handleShowAlert"
 import { useDispatch } from "react-redux"
 
 export default function Form() {
+  const isEditMode = new URLSearchParams(location.search).get("edit") === "true";
   const [cookies] = useCookies([Cookie.jwt])
   const dispatch = useDispatch()
   const { id } = useParams<{ id: string }>()
@@ -41,9 +42,9 @@ export default function Form() {
   }
 
   return (
-    <div className="py-12 max-w-5xl mx-auto">
+    <div className="max-w-5xl py-12 mx-auto">
       <div className="flex flex-col gap-4">
-        <EditableFormCard form={formProps} />
+      <EditableFormCard form={formProps} readOnly={!isEditMode} />
         <div className="flex flex-col gap-4">
           {questions.map((question: TemplateQuestion) => (
             <QuestionCard key={question._id} question={question} />

--- a/src/pages/Form/Form.tsx
+++ b/src/pages/Form/Form.tsx
@@ -1,6 +1,6 @@
 import { useGetFormQuery } from "../../features/user/backendApi"
 import Loader from "../../components/ui/Loader"
-import { useParams } from "react-router-dom"
+import { useParams, useSearchParams } from "react-router-dom"
 import EditableFormCard from "../../components/ui/EditableFormCard"
 import QuestionCard from "../../components/ui/QuestionCard"
 import { AlertType, Cookie, TemplateQuestion } from "../../utils/types"
@@ -10,7 +10,8 @@ import { handleShowAlert } from "../../utils/handleShowAlert"
 import { useDispatch } from "react-redux"
 
 export default function Form() {
-  const isEditMode = new URLSearchParams(location.search).get("edit") === "true";
+  const [searchParams] = useSearchParams();
+  const isEditMode = searchParams.get("edit") === "true";
   const [cookies] = useCookies([Cookie.jwt])
   const dispatch = useDispatch()
   const { id } = useParams<{ id: string }>()
@@ -44,10 +45,10 @@ export default function Form() {
   return (
     <div className="max-w-5xl py-12 mx-auto">
       <div className="flex flex-col gap-4">
-      <EditableFormCard form={formProps} readOnly={!isEditMode} />
+      <EditableFormCard form={formProps} readonly={!isEditMode} />
         <div className="flex flex-col gap-4">
           {questions.map((question: TemplateQuestion) => (
-            <QuestionCard key={question._id} question={question} />
+            <QuestionCard key={question._id} question={question} readonly={!isEditMode}/>
           ))}
         </div>
       </div>


### PR DESCRIPTION
**Description**

This PR enforces a read-only mode for the form viewing, ensuring that admins cannot make changes unless they explicitly switch to edit mode. https://trello.com/c/3szwfbuR

**Tasks Completed**
- [x] Makes the form viewing interface strictly read-only.
- [x]  Removed input interactions when in view mode.
- [x] Ensured admins can edit form data only after clicking "Edit."
