### PR TITLE
Make Filtering Controls Visible

### DIFF
--- a/src/components/ui/OverViewTable.tsx
+++ b/src/components/ui/OverViewTable.tsx
@@ -380,6 +380,16 @@ export default function OverViewTable({
           "& .MuiDataGrid-row.completed:hover": {
             bgcolor: "#86EFAC",
           },
+          '& .MuiDataGrid-iconButtonContainer': {
+             visibility: 'visible',
+          },
+          '& .MuiDataGrid-sortIcon': {
+             opacity: 'inherit !important',
+          },
+          "& .MuiDataGrid-menuIcon": {
+             visibility: "visible !important",
+             width: "auto",
+          },
         }}
       />
     </>

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -150,12 +150,15 @@ export const customizeDataGridStyles = {
   "& .MuiDataGrid-columnHeaderTitleContainer": {
     visibility: "visible !important",
   },
+  '& .MuiDataGrid-iconButtonContainer': {
+   visibility: 'visible',
+  },
+  '& .MuiDataGrid-sortIcon': {
+   opacity: 'inherit !important',
+  },
   "& .MuiDataGrid-menuIcon": {
-    visibility: "visible !important",
-    width: "auto",
+   visibility: "visible !important",
+   width: "auto",
   },
-  "& .MuiDataGrid-sortIcon": {
-    visibility: "visible !important",
-    opacity: 1,
-  },
+  
 }

--- a/src/utils/data.ts
+++ b/src/utils/data.ts
@@ -144,4 +144,18 @@ export const customizeDataGridStyles = {
   "& .MuiDataGrid-cell:focus": {
     outline: "none",
   },
+  "& .MuiDataGrid-columnHeaderDraggableContainer": {
+    visibility: "visible !important",
+  },
+  "& .MuiDataGrid-columnHeaderTitleContainer": {
+    visibility: "visible !important",
+  },
+  "& .MuiDataGrid-menuIcon": {
+    visibility: "visible !important",
+    width: "auto",
+  },
+  "& .MuiDataGrid-sortIcon": {
+    visibility: "visible !important",
+    opacity: 1,
+  },
 }


### PR DESCRIPTION
This PR implements the changes required to make the filtering controls and sort icons always visible on the `DataGrid` components!
The link to the [Filtering controls Trello card](https://trello.com/c/5qqqU89x/130-make-filtering-controls-visible)
The link to the [Sort controls Trello card](https://trello.com/c/WO8BOjyp/131-make-sorting-controls-visible)