### PR TITLE
(Admin) Inactivate edit button for previous cohorts

### DIFF
--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -26,9 +26,9 @@ const Button = ({
 
   const primaryClasses = {
     "text-primary-dark bg-white border-primary-dark border px-6":
-      variant === ButtonVariant.Primary && outlined,
+      variant === ButtonVariant.Primary && outlined && !disabled,
     "bg-primary-dark text-white":
-      variant === ButtonVariant.Primary && !outlined,
+      variant === ButtonVariant.Primary && !outlined && !disabled,
   }
 
   const sizeClasses = {
@@ -37,11 +37,16 @@ const Button = ({
     "px-7 py-3 text-xl w-full": size === ButtonSize.Large,
   }
 
+  const disabledClasses = {
+    "border border-gray-500 text-gray-500 px-6 bg-gray-200": disabled,
+  }
+
   return (
     <button
       onClick={onClick}
       className={classNames(
         "rounded-lg",
+        disabledClasses,
         dangerClasses,
         primaryClasses,
         sizeClasses,

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -18,27 +18,28 @@ const Button = ({
   disabled,
   onClick,
 }: ButtonProps) => {
-  const dangerClasses = {
+  const disabledClasses = {
+    "text-white bg-gray-400 border border-gray-400 cursor-not-allowed px-6":
+      disabled,
+  }
+
+  const dangerClasses = !disabled && {
     "text-red-500 bg-white border-red-500 border px-6":
       variant === ButtonVariant.Danger && outlined,
     "bg-red-500 text-white px-6": variant === ButtonVariant.Danger && !outlined,
   }
 
-  const primaryClasses = {
+  const primaryClasses = !disabled && {
     "text-primary-dark bg-white border-primary-dark border px-6":
-      variant === ButtonVariant.Primary && outlined && !disabled,
+      variant === ButtonVariant.Primary && outlined,
     "bg-primary-dark text-white":
-      variant === ButtonVariant.Primary && !outlined && !disabled,
+      variant === ButtonVariant.Primary && !outlined,
   }
 
   const sizeClasses = {
     "px-4 py-1": size === ButtonSize.Small,
     "px-4 py-2": size === ButtonSize.Medium,
     "px-7 py-3 text-xl w-full": size === ButtonSize.Large,
-  }
-
-  const disabledClasses = {
-    "border border-gray-500 text-gray-500 px-6 bg-gray-200": disabled,
   }
 
   return (

--- a/src/pages/Cohort/Cohorts.tsx
+++ b/src/pages/Cohort/Cohorts.tsx
@@ -1,21 +1,20 @@
+import { Box, Modal, Typography } from "@mui/material"
+import { DataGrid, GridColDef } from "@mui/x-data-grid"
+import { useState } from "react"
+import { useCookies } from "react-cookie"
+import { useDispatch } from "react-redux"
+import UpdateCohortModal from "../../components/modals/UpdateCohortModal"
+import TableSkeleton from "../../components/skeletons/TableSkeleton"
+import Button from "../../components/ui/Button"
 import {
   useCreateCohortMutation,
   useGetAllCohortsQuery,
 } from "../../features/user/backendApi"
-import { DataGrid } from "@mui/x-data-grid"
-import Button from "../../components/ui/Button"
+import { customizeDataGridStyles } from "../../utils/data"
+import { handleShowAlert } from "../../utils/handleShowAlert"
+import { getErrorInfo } from "../../utils/helper"
 import { AlertType, ButtonSize, Cookie, Stage } from "../../utils/types"
 import CreateCohortForm from "./CreateCohortForm"
-import { Box, Modal, Typography } from "@mui/material"
-import { useState } from "react"
-import { handleShowAlert } from "../../utils/handleShowAlert"
-import { useDispatch } from "react-redux"
-import { getErrorInfo } from "../../utils/helper"
-import { useCookies } from "react-cookie"
-import { customizeDataGridStyles } from "../../utils/data"
-import TableSkeleton from "../../components/skeletons/TableSkeleton"
-import { GridColDef } from "@mui/x-data-grid"
-import UpdateCohortModal from "../../components/modals/UpdateCohortModal"
 
 type TCohort = {
   applicants: number
@@ -27,6 +26,7 @@ type TCohort = {
   trainees: number
   _id: string
   trainingStartDate: string
+  isActive: boolean
 }
 type TCohortWithId = TCohort & { readonly id: string }
 
@@ -110,6 +110,7 @@ export default function Cohorts() {
             <Button
               size={ButtonSize.Small}
               outlined
+              disabled={!row.isActive}
               onClick={() =>
                 setCohortToUpdate({
                   _id: row.id,


### PR DESCRIPTION
Trello card: [(Admin) Inactivate edit button for previous cohorts](https://trello.com/c/7BvmLEOZ/102-admin-inactivate-edit-button-for-previous-cohorts)

### What was done

Visually differentiate the edit button for the active and inactive cohorts and disable the edit button for the inactive cohorts.