### PR TITLE
Give visual feedbacks in the process of deactivating an admin

### DIFF
--- a/src/components/modals/AdminStatusConfirmationModal.tsx
+++ b/src/components/modals/AdminStatusConfirmationModal.tsx
@@ -1,0 +1,61 @@
+import { Modal } from "@mui/material"
+import Button from "../ui/Button"
+import { ButtonVariant } from "../../utils/types"
+import Loader from "../ui/Loader"
+
+interface AdminStatusConfirmationModalProps {
+  isOpen: boolean
+  onClose: () => void
+  isUserActive: boolean
+  userName: string
+  onConfirm: () => Promise<void>
+  isLoading: boolean
+}
+
+export default function AdminStatusConfirmationModal({
+  isOpen,
+  onClose,
+  isUserActive,
+  onConfirm,
+  isLoading,
+}: AdminStatusConfirmationModalProps) {
+  const action = isUserActive ? "deactivate" : "activate"
+  const actionCapitalized = isUserActive ? "Deactivate" : "Activate"
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={onClose}
+      aria-describedby={`Confirm ${action} admin`}
+      component="div"
+      className="max-w-md mx-auto flex items-center"
+    >
+      <div className="flex flex-col gap-6 w-full bg-white p-5 rounded-xl">
+        <h1 className="text-center text-2xl font-semibold">
+          {actionCapitalized} an Admin
+        </h1>
+
+        <p className="text-center">Confirm if you want to {action} an Admin</p>
+
+        <div className="flex justify-around gap-2">
+          <Button outlined onClick={onClose}>
+            Cancel
+          </Button>
+
+          <Button
+            onClick={onConfirm}
+            disabled={isLoading}
+            variant={
+              isUserActive ? ButtonVariant.Danger : ButtonVariant.Primary
+            }
+          >
+            <span className="flex items-center gap-1">
+              {isLoading ? <Loader borderColor="#fff" size="xs" /> : ""}
+              <span>{actionCapitalized}</span>
+            </span>
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/modals/EditUserModal.tsx
+++ b/src/components/modals/EditUserModal.tsx
@@ -60,13 +60,10 @@ export default function EditUserModal({
     useToggleUserActiveStatusMutation()
   const [showConfirmation, setShowConfirmation] = useState(false)
 
-  // Set a default value for active if it's undefined (assuming active by default)
-  // Using defaultValues directly here may cause issues on re-renders, so store it in state
   const [isUserActive, setIsUserActive] = useState(
     defaultValues.active !== false,
   )
 
-  // Update the active state when defaultValues changes
   useEffect(() => {
     setIsUserActive(defaultValues.active !== false)
   }, [defaultValues])
@@ -133,7 +130,6 @@ export default function EditUserModal({
     }
   }
 
-  // Only show activate/deactivate button for admin users
   const showActivateButton = defaultValues.role === UserRole.Admin
   const activationButtonText = isUserActive ? "Deactivate" : "Activate"
 

--- a/src/components/modals/EditUserModal.tsx
+++ b/src/components/modals/EditUserModal.tsx
@@ -1,7 +1,13 @@
 import { useForm } from "react-hook-form"
 import Button from "../ui/Button"
 import { Modal } from "@mui/material"
-import { AlertType, Cookie, User, UserRole } from "../../utils/types"
+import {
+  AlertType,
+  ButtonVariant,
+  Cookie,
+  User,
+  UserRole,
+} from "../../utils/types"
 import Input from "../ui/Input"
 import Select from "../ui/Select"
 import { z } from "zod"
@@ -216,7 +222,9 @@ export default function EditUserModal({
             <Button
               onClick={handleToggleActive}
               disabled={isToggleLoading}
-              className={isUserActive ? "bg-red-600 hover:bg-red-700" : ""}
+              variant={
+                isUserActive ? ButtonVariant.Danger : ButtonVariant.Primary
+              }
             >
               <span className="flex items-center gap-1">
                 {isToggleLoading ? <Loader borderColor="#fff" size="xs" /> : ""}

--- a/src/components/modals/EditUserModal.tsx
+++ b/src/components/modals/EditUserModal.tsx
@@ -144,12 +144,12 @@ export default function EditUserModal({
         >
           <h1 className="text-center text-3xl font-semibold">Edit user</h1>
           <Input
-            register={{ ...register("name") }}
+            register={register("name")}
             label="Name"
             error={errors.name?.message}
           />
           <Input
-            register={{ ...register("email") }}
+            register={register("email")}
             label="Email"
             disabled
             error={errors.email?.message}

--- a/src/components/modals/EditUserModal.tsx
+++ b/src/components/modals/EditUserModal.tsx
@@ -1,13 +1,7 @@
 import { useForm } from "react-hook-form"
 import Button from "../ui/Button"
 import { Modal } from "@mui/material"
-import {
-  AlertType,
-  ButtonVariant,
-  Cookie,
-  User,
-  UserRole,
-} from "../../utils/types"
+import { AlertType, Cookie, User, UserRole } from "../../utils/types"
 import Input from "../ui/Input"
 import Select from "../ui/Select"
 import { z } from "zod"
@@ -22,6 +16,7 @@ import {
 } from "../../features/user/backendApi"
 import Loader from "../ui/Loader"
 import { useState, useEffect } from "react"
+import AdminStatusConfirmationModal from "./AdminStatusConfirmationModal"
 
 const selectOptions = [
   { value: UserRole.Prospect, label: "Prospect" },
@@ -168,10 +163,7 @@ export default function EditUserModal({
 
           {showActivateButton && (
             <div className="mt-2">
-              <Button
-                onClick={() => setShowConfirmation(true)}
-                className={`w-full ${isUserActive ? "bg-red-600 hover:bg-red-700" : ""}`}
-              >
+              <Button onClick={() => setShowConfirmation(true)}>
                 {activationButtonText}
               </Button>
             </div>
@@ -192,44 +184,15 @@ export default function EditUserModal({
         </form>
       </Modal>
 
-      {/* Confirmation Modal */}
-      <Modal
-        open={showConfirmation}
+      {/* Admin status confirmation modal */}
+      <AdminStatusConfirmationModal
+        isOpen={showConfirmation}
         onClose={() => setShowConfirmation(false)}
-        aria-describedby="Confirm deactivation"
-        component="div"
-        className="max-w-md mx-auto flex items-center"
-      >
-        <div className="flex flex-col gap-6 w-full bg-white p-5 rounded-xl">
-          <h1 className="text-center text-2xl font-semibold">
-            {isUserActive ? "Deactivate an Admin" : "Activate an Admin"}
-          </h1>
-
-          <p className="text-center">
-            Confirm if you want to {isUserActive ? "deactivate" : "activate"} an
-            Admin
-          </p>
-
-          <div className="flex justify-around gap-2">
-            <Button outlined onClick={() => setShowConfirmation(false)}>
-              Cancel
-            </Button>
-
-            <Button
-              onClick={handleToggleActive}
-              disabled={isToggleLoading}
-              variant={
-                isUserActive ? ButtonVariant.Danger : ButtonVariant.Primary
-              }
-            >
-              <span className="flex items-center gap-1">
-                {isToggleLoading ? <Loader borderColor="#fff" size="xs" /> : ""}
-                <span>{isUserActive ? "Deactivate" : "Activate"}</span>
-              </span>
-            </Button>
-          </div>
-        </div>
-      </Modal>
+        isUserActive={isUserActive}
+        userName={defaultValues.name}
+        onConfirm={handleToggleActive}
+        isLoading={isToggleLoading}
+      />
     </>
   )
 }

--- a/src/components/modals/EditUserModal.tsx
+++ b/src/components/modals/EditUserModal.tsx
@@ -11,11 +11,11 @@ import { handleShowAlert } from "../../utils/handleShowAlert"
 import { useDispatch } from "react-redux"
 import { useCookies } from "react-cookie"
 import {
-  useUpdateUserMutation,
   useToggleUserActiveStatusMutation,
+  useUpdateUserMutation,
 } from "../../features/user/backendApi"
 import Loader from "../ui/Loader"
-import { useState } from "react"
+import { useState, useEffect } from "react"
 
 const selectOptions = [
   { value: UserRole.Prospect, label: "Prospect" },
@@ -54,6 +54,17 @@ export default function EditUserModal({
     useToggleUserActiveStatusMutation()
   const [showConfirmation, setShowConfirmation] = useState(false)
 
+  // Set a default value for active if it's undefined (assuming active by default)
+  // Using defaultValues directly here may cause issues on re-renders, so store it in state
+  const [isUserActive, setIsUserActive] = useState(
+    defaultValues.active !== false,
+  )
+
+  // Update the active state when defaultValues changes
+  useEffect(() => {
+    setIsUserActive(defaultValues.active !== false)
+  }, [defaultValues])
+
   const {
     register,
     handleSubmit,
@@ -65,6 +76,7 @@ export default function EditUserModal({
       name: defaultValues.name,
       email: defaultValues.email,
       role: defaultValues.role,
+      active: defaultValues.active,
     },
   })
 
@@ -99,7 +111,7 @@ export default function EditUserModal({
         userId: defaultValues._id,
       }).unwrap()
 
-      const action = defaultValues.active ? "deactivated" : "activated"
+      const action = isUserActive ? "deactivated" : "activated"
       handleShowAlert(dispatch, {
         type: AlertType.Success,
         message: `Admin ${defaultValues.name} was ${action} successfully.`,
@@ -117,18 +129,17 @@ export default function EditUserModal({
 
   // Only show activate/deactivate button for admin users
   const showActivateButton = defaultValues.role === UserRole.Admin
-  const activationButtonText = defaultValues.active
-    ? "Deactivate Admin"
-    : "Activate Admin"
+  const activationButtonText = isUserActive ? "Deactivate" : "Activate"
 
   return (
     <>
+      {/* Edit Modal */}
       <Modal
-        open={isOpen}
+        open={isOpen && !showConfirmation}
         onClose={onClose}
         aria-describedby="Add user"
         component="div"
-        className="max-w-md mx-auto flex items-center "
+        className="max-w-md mx-auto flex items-center"
       >
         <form
           onSubmit={handleSubmit(onSubmit)}
@@ -156,9 +167,8 @@ export default function EditUserModal({
           {showActivateButton && (
             <div className="mt-2">
               <Button
-                outlined={!defaultValues.active}
                 onClick={() => setShowConfirmation(true)}
-                className="w-full"
+                className={`w-full ${isUserActive ? "bg-red-600 hover:bg-red-700" : ""}`}
               >
                 {activationButtonText}
               </Button>
@@ -173,7 +183,7 @@ export default function EditUserModal({
             <Button type="submit" disabled={isUserLoading || !isDirty}>
               <span className="flex items-center gap-1">
                 {isUserLoading ? <Loader borderColor="#fff" size="xs" /> : ""}
-                <span>Save </span>
+                <span>Save</span>
               </span>
             </Button>
           </div>
@@ -189,21 +199,28 @@ export default function EditUserModal({
         className="max-w-md mx-auto flex items-center"
       >
         <div className="flex flex-col gap-6 w-full bg-white p-5 rounded-xl">
-          <h2 className="text-center text-xl font-semibold">
-            {defaultValues.active
-              ? "Confirm if you want to deactivate an Admin"
-              : "Confirm if you want to activate an Admin"}
-          </h2>
+          <h1 className="text-center text-2xl font-semibold">
+            {isUserActive ? "Deactivate an Admin" : "Activate an Admin"}
+          </h1>
+
+          <p className="text-center">
+            Confirm if you want to {isUserActive ? "deactivate" : "activate"} an
+            Admin
+          </p>
 
           <div className="flex justify-around gap-2">
             <Button outlined onClick={() => setShowConfirmation(false)}>
               Cancel
             </Button>
 
-            <Button onClick={handleToggleActive} disabled={isToggleLoading}>
+            <Button
+              onClick={handleToggleActive}
+              disabled={isToggleLoading}
+              className={isUserActive ? "bg-red-600 hover:bg-red-700" : ""}
+            >
               <span className="flex items-center gap-1">
                 {isToggleLoading ? <Loader borderColor="#fff" size="xs" /> : ""}
-                <span>Confirm</span>
+                <span>{isUserActive ? "Deactivate" : "Activate"}</span>
               </span>
             </Button>
           </div>

--- a/src/components/modals/EditUserModal.tsx
+++ b/src/components/modals/EditUserModal.tsx
@@ -13,6 +13,7 @@ import { useCookies } from "react-cookie"
 import {
   useToggleUserActiveStatusMutation,
   useUpdateUserMutation,
+  useGetProfileQuery,
 } from "../../features/user/backendApi"
 import Loader from "../ui/Loader"
 import { useState, useEffect } from "react"
@@ -54,6 +55,7 @@ export default function EditUserModal({
   const [toggleUserActive, { isLoading: isToggleLoading }] =
     useToggleUserActiveStatusMutation()
   const [showConfirmation, setShowConfirmation] = useState(false)
+  const { data: loggedInUser } = useGetProfileQuery(cookies.jwt)
 
   const [isUserActive, setIsUserActive] = useState(
     defaultValues.active !== false,
@@ -125,7 +127,9 @@ export default function EditUserModal({
     }
   }
 
-  const showActivateButton = defaultValues.role === UserRole.Admin
+  const showActivateButton =
+    defaultValues.role === UserRole.Admin &&
+    defaultValues.userId !== loggedInUser.userId
   const activationButtonText = isUserActive ? "Deactivate" : "Activate"
 
   return (

--- a/src/components/modals/EditUserModal.tsx
+++ b/src/components/modals/EditUserModal.tsx
@@ -10,8 +10,12 @@ import { getErrorInfo } from "../../utils/helper"
 import { handleShowAlert } from "../../utils/handleShowAlert"
 import { useDispatch } from "react-redux"
 import { useCookies } from "react-cookie"
-import { useUpdateUserMutation } from "../../features/user/backendApi"
+import {
+  useUpdateUserMutation,
+  useToggleUserActiveStatusMutation,
+} from "../../features/user/backendApi"
 import Loader from "../ui/Loader"
+import { useState } from "react"
 
 const selectOptions = [
   { value: UserRole.Prospect, label: "Prospect" },
@@ -46,6 +50,9 @@ export default function EditUserModal({
   const dispatch = useDispatch()
   const [updateUser, { isLoading: isUserLoading, reset: resetUpdateUser }] =
     useUpdateUserMutation()
+  const [toggleUserActive, { isLoading: isToggleLoading }] =
+    useToggleUserActiveStatusMutation()
+  const [showConfirmation, setShowConfirmation] = useState(false)
 
   const {
     register,
@@ -85,50 +92,123 @@ export default function EditUserModal({
     }
   }
 
+  const handleToggleActive = async () => {
+    try {
+      await toggleUserActive({
+        jwt: cookies.jwt,
+        userId: defaultValues._id,
+      }).unwrap()
+
+      const action = defaultValues.active ? "deactivated" : "activated"
+      handleShowAlert(dispatch, {
+        type: AlertType.Success,
+        message: `Admin ${defaultValues.name} was ${action} successfully.`,
+      })
+      setShowConfirmation(false)
+      onClose()
+    } catch (error) {
+      const { message } = getErrorInfo(error)
+      handleShowAlert(dispatch, {
+        type: AlertType.Error,
+        message,
+      })
+    }
+  }
+
+  // Only show activate/deactivate button for admin users
+  const showActivateButton = defaultValues.role === UserRole.Admin
+  const activationButtonText = defaultValues.active
+    ? "Deactivate Admin"
+    : "Activate Admin"
+
   return (
-    <Modal
-      open={isOpen}
-      onClose={onClose}
-      aria-describedby="Add user"
-      component="div"
-      className="max-w-md mx-auto flex items-center "
-    >
-      <form
-        onSubmit={handleSubmit(onSubmit)}
-        className="flex flex-col gap-6 w-full bg-white p-5 rounded-xl"
+    <>
+      <Modal
+        open={isOpen}
+        onClose={onClose}
+        aria-describedby="Add user"
+        component="div"
+        className="max-w-md mx-auto flex items-center "
       >
-        <h1 className="text-center text-3xl font-semibold">Edit user</h1>
-        <Input
-          register={{ ...register("name") }}
-          label="Name"
-          error={errors.name?.message}
-        />
-        <Input
-          register={{ ...register("email") }}
-          label="Email"
-          disabled
-          error={errors.email?.message}
-        />
-        <Select
-          options={selectOptions}
-          label="Role"
-          register={register("role")}
-          error={errors.role?.message}
-        />
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="flex flex-col gap-6 w-full bg-white p-5 rounded-xl"
+        >
+          <h1 className="text-center text-3xl font-semibold">Edit user</h1>
+          <Input
+            register={{ ...register("name") }}
+            label="Name"
+            error={errors.name?.message}
+          />
+          <Input
+            register={{ ...register("email") }}
+            label="Email"
+            disabled
+            error={errors.email?.message}
+          />
+          <Select
+            options={selectOptions}
+            label="Role"
+            register={register("role")}
+            error={errors.role?.message}
+          />
 
-        <div className="flex justify-around gap-2">
-          <Button outlined onClick={onClose}>
-            Cancel
-          </Button>
+          {showActivateButton && (
+            <div className="mt-2">
+              <Button
+                outlined={!defaultValues.active}
+                onClick={() => setShowConfirmation(true)}
+                className="w-full"
+              >
+                {activationButtonText}
+              </Button>
+            </div>
+          )}
 
-          <Button type="submit" disabled={isUserLoading || !isDirty}>
-            <span className="flex items-center gap-1">
-              {isUserLoading ? <Loader borderColor="#fff" size="xs" /> : ""}
-              <span>Save </span>
-            </span>
-          </Button>
+          <div className="flex justify-around gap-2">
+            <Button outlined onClick={onClose}>
+              Cancel
+            </Button>
+
+            <Button type="submit" disabled={isUserLoading || !isDirty}>
+              <span className="flex items-center gap-1">
+                {isUserLoading ? <Loader borderColor="#fff" size="xs" /> : ""}
+                <span>Save </span>
+              </span>
+            </Button>
+          </div>
+        </form>
+      </Modal>
+
+      {/* Confirmation Modal */}
+      <Modal
+        open={showConfirmation}
+        onClose={() => setShowConfirmation(false)}
+        aria-describedby="Confirm deactivation"
+        component="div"
+        className="max-w-md mx-auto flex items-center"
+      >
+        <div className="flex flex-col gap-6 w-full bg-white p-5 rounded-xl">
+          <h2 className="text-center text-xl font-semibold">
+            {defaultValues.active
+              ? "Confirm if you want to deactivate an Admin"
+              : "Confirm if you want to activate an Admin"}
+          </h2>
+
+          <div className="flex justify-around gap-2">
+            <Button outlined onClick={() => setShowConfirmation(false)}>
+              Cancel
+            </Button>
+
+            <Button onClick={handleToggleActive} disabled={isToggleLoading}>
+              <span className="flex items-center gap-1">
+                {isToggleLoading ? <Loader borderColor="#fff" size="xs" /> : ""}
+                <span>Confirm</span>
+              </span>
+            </Button>
+          </div>
         </div>
-      </form>
-    </Modal>
+      </Modal>
+    </>
   )
 }

--- a/src/features/user/backendApi.ts
+++ b/src/features/user/backendApi.ts
@@ -121,6 +121,20 @@ export const backendApi: any = createApi({
       invalidatesTags: ["users"],
     }),
 
+    toggleUserActiveStatus: builder.mutation({
+      query: (args) => {
+        const { jwt, userId } = args
+        return {
+          url: `/users/${userId}/status`,
+          method: "PATCH",
+          headers: {
+            Authorization: `Bearer ${jwt}`,
+          },
+        }
+      },
+      invalidatesTags: ["users"],
+    }),
+
     editCoach: builder.mutation({
       query: (args) => {
         const { jwt, body, id } = args
@@ -575,6 +589,7 @@ export const {
   useVerifyApplicantMutation,
   useGetProfileQuery,
   useUpdateProfileMutation,
+  useToggleUserActiveStatusMutation,
   useResetPasswordMutation,
   useDeleteCoachMutation,
   useDeleteTraineeMutation,

--- a/src/pages/User/Users.tsx
+++ b/src/pages/User/Users.tsx
@@ -36,11 +36,7 @@ export default function Users() {
   const getRowClassName = (params: GridRowClassNameParams) => {
     const row = params.row as User
     // If the user is an admin and is inactive, apply grey styling
-    if (row.role === UserRole.Admin && row.active === false) {
-      return "bg-gray-200"
-    }
-
-    return ""
+    return row.role === UserRole.Admin && !row.active ? "bg-gray-200" : ""
   }
 
   const columns: GridColDef[] = [

--- a/src/pages/User/Users.tsx
+++ b/src/pages/User/Users.tsx
@@ -95,6 +95,7 @@ export default function Users() {
       name: user.name,
       email: user.email,
       role: user.role,
+      active: user.active,
     })) ?? []
 
   const handleCloseCreateUserModal = () =>

--- a/src/pages/User/Users.tsx
+++ b/src/pages/User/Users.tsx
@@ -28,6 +28,7 @@ export default function Users() {
     data: users,
     error: usersError,
     isFetching: usersIsFetching,
+    refetch,
   } = useGetUsersQuery({
     jwt: cookies.jwt,
   })
@@ -131,7 +132,11 @@ export default function Users() {
             <EditUserModal
               isOpen={Boolean(userInformation)}
               defaultValues={userInformation}
-              onClose={() => setTimeout(() => setUserInformation(null), 0)}
+              onClose={() => {
+                setTimeout(() => setUserInformation(null), 0)
+                // Refresh data after updating a user
+                refetch()
+              }}
             />
           </>
         )}

--- a/src/pages/User/Users.tsx
+++ b/src/pages/User/Users.tsx
@@ -11,7 +11,7 @@ import { useCookies } from "react-cookie"
 import { useDispatch } from "react-redux"
 import { handleShowAlert } from "../../utils/handleShowAlert"
 import { getErrorInfo } from "../../utils/helper"
-import { DataGrid, GridColDef } from "@mui/x-data-grid"
+import { DataGrid, GridColDef, GridRowClassNameParams } from "@mui/x-data-grid"
 import EditIcon from "../../assets/EditIcon"
 import { useState } from "react"
 import CreateUser from "../../components/modals/CreateUser"
@@ -31,6 +31,16 @@ export default function Users() {
   } = useGetUsersQuery({
     jwt: cookies.jwt,
   })
+
+  const getRowClassName = (params: GridRowClassNameParams) => {
+    const row = params.row as User
+    // If the user is an admin and is inactive, apply grey styling
+    if (row.role === UserRole.Admin && row.active === false) {
+      return "bg-gray-200"
+    }
+
+    return ""
+  }
 
   const columns: GridColDef[] = [
     {
@@ -124,7 +134,12 @@ export default function Users() {
             />
           </>
         )}
-        <DataGrid columns={columns} rows={rows} sx={customizeDataGridStyles} />
+        <DataGrid
+          columns={columns}
+          rows={rows}
+          sx={customizeDataGridStyles}
+          getRowClassName={getRowClassName}
+        />
       </div>
     </>
   )

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -17,6 +17,7 @@ export interface User {
   email: string
   role: UserRole
   coach: Omit<User, "coach">
+  active?: boolean
 }
 
 export interface Cohort {


### PR DESCRIPTION
### Tasks Completed

- Enable the admin to deactivate another admin.
- Prevent the deactivated admin from performing any actions.
- Disable the authentication of the deactivated admin.
- Admins access the “deactivate” button in the edit modal after clicking the edit button on the users overview for admins.

Trello Card: https://trello.com/c/oVTbTDT3/121-give-visual-feedbacks-in-the-process-of-deactivating-an-admin