### PR TITLE
(Admin) "No" Column Data Format Error on cohort overview

### DIFF
--- a/src/pages/Cohort/Cohorts.tsx
+++ b/src/pages/Cohort/Cohorts.tsx
@@ -26,6 +26,7 @@ type TCohort = {
   stages: Stage[]
   trainees: number
   _id: string
+  cohortId: string
   trainingStartDate: string
   isActive: boolean
 }
@@ -65,7 +66,7 @@ export default function Cohorts() {
   const modifiedArray: TCohortWithId[] = data?.map((row: TCohort) => {
     return {
       ...row,
-      id: row._id,
+      id: row.cohortId,
     }
   })
 
@@ -113,6 +114,7 @@ export default function Cohorts() {
               outlined
               onClick={() =>
                 setDisplayCohortDetails({
+                  cohortId: row.cohortId,
                   _id: row.id,
                   name: row.name,
                   description: row.description,


### PR DESCRIPTION
This PR resolves the "No" column to display only numerical values for accurate sorting on `cohort overview` section.
Trello: https://trello.com/c/K7thxqB4